### PR TITLE
add rule for 404.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,14 @@ STATIC=$(STATIC_SRC:static/%=public/%)
 public: public/index.min.js $(STATIC)
 	touch -m $@
 
-public/index.js: elm.json src/Api $(ELM_SRC) src/Routes.elm
+public/index.js: elm.json src/Api $(ELM_SRC) src/Routes.elm public/404.html
 	npx elm make src/Main.elm --output $@ --optimize
 
 public/index.min.js: public/index.js node_modules
 	./node_modules/.bin/uglifyjs $< --compress "pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe" | ./node_modules/.bin/uglifyjs --mangle > $@
+
+public/404.html: public/not-found/index.html
+	cp $< $@
 
 public/%: static/%
 	@mkdir -p $(@D)


### PR DESCRIPTION
creates a custom "not found" page on Netlify, per their docs: https://www.netlify.com/docs/redirects/#custom-404